### PR TITLE
Update Dockerfile for Centos 7 EOL (and rsync 3.4.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM centos:centos7
 
-ARG RSYNC_VERSION=v3.2.7
+ARG RSYNC_VERSION=v3.4.1
+
+# fix yum repo URLs for CentOS 7 EOL
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo && \
+sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo && \
+sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
 
 RUN yum -y install \
 epel-release \
@@ -29,7 +34,7 @@ xxhash-devel \
 python3 -mpip install --user commonmark
 
 RUN cd / && \ 
-wget https://download-ib01.fedoraproject.org/pub/epel/7/SRPMS/Packages/x/xxhash-0.8.2-1.el7.src.rpm && \
+wget https://archives.fedoraproject.org/pub/archive/epel/7/SRPMS/Packages/x/xxhash-0.8.2-1.el7.src.rpm && \
 rpm -ivh xxhash-*.el7.src.rpm && \
 cd ~/rpmbuild/SPECS && \
 rpmbuild -bp xxhash.spec && \
@@ -37,7 +42,7 @@ cd ~/rpmbuild/BUILD/xxHash-*/ && \
 make install
 
 RUN cd / && \
-git clone https://github.com/WayneD/rsync.git && \
+git clone https://github.com/RsyncProject/rsync.git && \
 cd rsync && \
 git checkout $RSYNC_VERSION
  
@@ -45,8 +50,10 @@ WORKDIR /rsync
 
 RUN cd /rsync && \
 LIBS="-ldl" ./configure && \
-make -B CFLAGS="-static" 
+make -B CFLAGS="-static -std=c99"
 
 RUN echo If build was successful, below output should state: 'not a dynamic executable' && \
 ldd rsync || \
 true
+
+RUN ./rsync -V


### PR DESCRIPTION
In the event this is useful - here are some updates to the Dockerfile to allow the rsync build to continue to work in CentOS 7

(and also update to latest rsync 3.4.1 if desired)